### PR TITLE
Add per visit metric

### DIFF
--- a/notebooks/visit_verify.ipynb
+++ b/notebooks/visit_verify.ipynb
@@ -119,26 +119,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
-    "# Testing with extend function\n",
-    "src_catalog_0 = butler.getDirect(src_refs[0])\n",
-    "src_catalog_1 = butler.getDirect(src_refs[1])\n",
-    "print(len(src_catalog_0))\n",
-    "print(len(src_catalog_1))\n",
-    "#type(src_catalog_0)\n",
-    "#src_catalog_0.append(src_catalog_1.Record)\n",
-    "src_catalog_0.extend(src_catalog_1)\n",
-    "src_catalog_0.extend(src_catalog_1)\n",
-    "len(src_catalog_0)\n",
-    "\"\"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Get the number of unique visits\n",
     "len(np.unique([ref.dataId['visit'] for ref in src_refs]))"
    ]

--- a/notebooks/visit_verify.ipynb
+++ b/notebooks/visit_verify.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Butler Per-Visit Checker\n",
+    "\n",
+    "This is a simple notebook to verify that the per-visit metrics are doing what we expect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "\n",
+    "import lsst.daf.butler as dafButler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Which version of the Stack am I using?\n",
+    "!eups list -s | grep lsst_distrib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo = '/home/kbechtol/DATA/TEST_W_2020_21/ci_hsc_gen3'\n",
+    "\n",
+    "config = os.path.join(repo,'DATA','butler.yaml')\n",
+    "\n",
+    "\n",
+    "try: butler = dafButler.Butler(config=config)\n",
+    "except ValueError as e: print(e)\n",
+    "\n",
+    "butler = dafButler.Butler(config=config)\n",
+    "registry = butler.registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for c in registry.queryCollections():\n",
+    "    print(c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x in registry.queryDatasetTypes():\n",
+    "    print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collections = 'visitTest'\n",
+    "#collections = 'shared/ci_hsc_output'\n",
+    "kwargs = {'abstract_filter': 'r'}\n",
+    "src_refs = list(registry.queryDatasets('src', collections=collections, **kwargs))\n",
+    "nsrcMeasVisit_refs = list(registry.queryDatasets('metricvalue_info_nsrcMeasVisit', collections=collections, **kwargs))\n",
+    "sum_nsrcMeasVisit_refs = list(registry.queryDatasets('metricvalue_Sum_info_nsrcMeasVisit', collections=collections, **kwargs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(src_refs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ref in src_refs:\n",
+    "    src_catalog = butler.getDirect(ref)\n",
+    "    print(ref.dataId, len(src_catalog))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.sum([len(butler.getDirect(ref)) for ref in src_refs])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "# Testing with extend function\n",
+    "src_catalog_0 = butler.getDirect(src_refs[0])\n",
+    "src_catalog_1 = butler.getDirect(src_refs[1])\n",
+    "print(len(src_catalog_0))\n",
+    "print(len(src_catalog_1))\n",
+    "#type(src_catalog_0)\n",
+    "#src_catalog_0.append(src_catalog_1.Record)\n",
+    "src_catalog_0.extend(src_catalog_1)\n",
+    "src_catalog_0.extend(src_catalog_1)\n",
+    "len(src_catalog_0)\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the number of unique visits\n",
+    "len(np.unique([ref.dataId['visit'] for ref in src_refs]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(nsrcMeasVisit_refs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ref in nsrcMeasVisit_refs:\n",
+    "    measurement = butler.getDirect(ref)\n",
+    "    print(ref.dataId, measurement.quantity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.sum(u.Quantity([butler.getDirect(ref).quantity for ref in nsrcMeasVisit_refs]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(sum_nsrcMeasVisit_refs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ref in sum_nsrcMeasVisit_refs:\n",
+    "    measurement = butler.getDirect(ref)\n",
+    "    print(ref.dataId, measurement.quantity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.sum(u.Quantity([butler.getDirect(ref).quantity for ref in sum_nsrcMeasVisit_refs]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pipelines/matched_analysis.yaml
+++ b/pipelines/matched_analysis.yaml
@@ -61,5 +61,5 @@ tasks:
       connections.package: info
       connections.metric: nsrcMeas
       python: |
-        from MatchedCatalogMeasureTasks import NumSourcesTask
+        from GeneralMeasureTasks import NumSourcesTask
         config.measure.retarget(NumSourcesTask)

--- a/pipelines/visit_agg.yaml
+++ b/pipelines/visit_agg.yaml
@@ -1,0 +1,8 @@
+description: Compute aggregate metrics from a list of individual measurements
+tasks:
+  agg_sum_nsrcVisit:
+    class: VisitAggregation.VisitAggregationTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasVisit
+      connections.agg_name: Sum

--- a/pipelines/visit_analysis.yaml
+++ b/pipelines/visit_analysis.yaml
@@ -1,0 +1,10 @@
+description: Compute metrics from single-visit catalogs
+tasks:
+  nsrcMeasVisit:
+    class: VisitAnalysis.VisitAnalysisTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasVisit
+      python: |
+        from VisitMeasureTasks import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)

--- a/pipelines/visit_analysis.yaml
+++ b/pipelines/visit_analysis.yaml
@@ -6,5 +6,5 @@ tasks:
       connections.package: info
       connections.metric: nsrcMeasVisit
       python: |
-        from VisitMeasureTasks import NumSourcesTask
+        from GeneralMeasureTasks import NumSourcesTask
         config.measure.retarget(NumSourcesTask)

--- a/pipelines/visit_analysis.yaml
+++ b/pipelines/visit_analysis.yaml
@@ -1,9 +1,9 @@
 description: Compute metrics from single-visit catalogs
 tasks:
-  nsrcMeasVisitTest:
+  nsrcMeasVisit:
     class: VisitAnalysis.VisitAnalysisTask
     config:
-      connections.package: test
+      connections.package: info
       connections.metric: nsrcMeasVisit
       python: |
         from VisitMeasureTasks import NumSourcesTask

--- a/pipelines/visit_analysis.yaml
+++ b/pipelines/visit_analysis.yaml
@@ -1,9 +1,9 @@
 description: Compute metrics from single-visit catalogs
 tasks:
-  nsrcMeasVisit:
+  nsrcMeasVisitTest:
     class: VisitAnalysis.VisitAnalysisTask
     config:
-      connections.package: info
+      connections.package: test
       connections.metric: nsrcMeasVisit
       python: |
         from VisitMeasureTasks import NumSourcesTask

--- a/pipelines/visit_pipeline.yaml
+++ b/pipelines/visit_pipeline.yaml
@@ -1,0 +1,4 @@
+description: Visit metrics pipeline
+inherits:
+  - location: $METRIC_PIPE_DIR/pipelines/visit_analysis.yaml
+  - location: $METRIC_PIPE_DIR/pipelines/visit_agg.yaml

--- a/tasks/GeneralMeasureTasks.py
+++ b/tasks/GeneralMeasureTasks.py
@@ -1,0 +1,16 @@
+import astropy.units as u
+from lsst.pipe.base import Struct, Task
+from lsst.pex.config import Config
+from lsst.verify import Measurement
+
+
+class NumSourcesTask(Task):
+
+    ConfigClass = Config
+    _DefaultName = "numSourcesTask"
+
+    def run(self, catalog, metric_name):
+        self.log.info(f"Measuring {metric_name}")
+        nSources = len(catalog)
+        meas = Measurement("nsrcMeas", nSources * u.count)
+        return Struct(measurement=meas)

--- a/tasks/MatchedCatalogMeasureTasks.py
+++ b/tasks/MatchedCatalogMeasureTasks.py
@@ -10,17 +10,6 @@ from lsst.validate.drp.calcsrd.tex import (correlation_function_ellipticity_from
                                            select_bin_from_corr)
 from lsst.validate.drp.calcsrd.amx import calcRmsDistances
 
-class NumSourcesTask(Task):
-
-    ConfigClass = Config
-    _DefaultName = "numSourcesTask"
-
-    def run(self, matchedCatalog, metric_name):
-        self.log.info(f"Counting sources in matched catalog")
-        nSources = len(matchedCatalog)
-        meas = Measurement("nsrcMeas", nSources * u.count)
-        return Struct(measurement=meas)
-
 
 class PA1TaskConfig(Config):
     brightSnrMin = Field(doc="Minimum median SNR for a source to be considered bright.",

--- a/tasks/MatchedCatalogsAnalysis.py
+++ b/tasks/MatchedCatalogsAnalysis.py
@@ -2,11 +2,10 @@ import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
 
-from MatchedCatalogMeasureTasks import NumSourcesTask
+from GeneralMeasureTasks import NumSourcesTask
+
 # The first thing to do is to define a Connections class. This will define all
 # the inputs and outputs that our task requires
-
-
 class MatchedCatalogAnalysisTaskConnections(MetricConnections,
                                     dimensions=("tract", "patch", "abstract_filter",
                                                 "instrument", "skymap")):

--- a/tasks/VisitAggregation.py
+++ b/tasks/VisitAggregation.py
@@ -1,0 +1,39 @@
+import astropy.units as u
+import numpy as np
+
+from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
+import lsst.pipe.base as pipeBase
+from lsst.verify import Measurement
+
+class VisitAggregationTaskConnections(MetricConnections,
+                                      defaultTemplates={'agg_name': None},
+                                      dimensions=("abstract_filter", "instrument")):
+    
+    measurements = pipeBase.connectionTypes.Input(doc="{package}_{metric}.",
+                                                  dimensions=("instrument", "visit", "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}",
+                                                  multiple=True)
+    
+    measurement = pipeBase.connectionTypes.Output(doc="{agg_name} {package}_{metric}.",
+                                                  dimensions=("instrument", "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{agg_name}_{package}_{metric}")
+    
+class VisitAggregationTaskConfig(MetricConfig,
+                                 pipelineConnections=VisitAggregationTaskConnections):
+    pass
+
+class VisitAggregationTask(MetricTask):
+
+    ConfigClass = VisitAggregationTaskConfig
+    _DefaultName = "visitAggregationTask"
+
+    def run(self, measurements):
+        package = self.config.connections.package
+        metric = self.config.connections.metric
+        agg = self.config.connections.agg_name.lower()
+        self.log.info(f"Computing the {agg} of {package}_{metric} values in single-visit catalogs")
+
+        value = getattr(np, agg)(u.Quantity([x.quantity for x in measurements if np.isfinite(x.quantity)]))
+        return pipeBase.Struct(measurement=Measurement(f"metricvalue_{agg}_{package}_{metric}", value))

--- a/tasks/VisitAnalysis.py
+++ b/tasks/VisitAnalysis.py
@@ -1,0 +1,43 @@
+import lsst.pipe.base as pipeBase
+import lsst.pex.config as pexConfig
+from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
+
+from VisitMeasureTasks import NumSourcesTask
+
+# The first thing to do is to define a Connections class. This will define all
+# the inputs and outputs that our task requires
+
+class VisitAnalysisTaskConnections(MetricConnections,
+                                   dimensions=("instrument", "visit", "detector", "abstract_filter")):
+    
+    source_catalog = pipeBase.connectionTypes.Input(doc="Source catalogs.",
+                                                    dimensions=("instrument", "visit", "detector", "abstract_filter"),
+                                                    storageClass="SourceCatalog",
+                                                    name="src")
+                                                    #multiple=True) # We might need to compile results by visit
+    
+    measurement = pipeBase.connectionTypes.Output(doc="Per-visit measurement.",
+                                                  dimensions=("instrument", "visit", "detector", "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+    
+class VisitAnalysisTaskConfig(MetricConfig,
+                              pipelineConnections=VisitAnalysisTaskConnections):
+    measure = pexConfig.ConfigurableField(
+        # This task is meant to make measurements of various types.
+        # The default task is, therefore, a bit of a place holder.
+        # It is expected that this will be overridden in the pipeline
+        # definition in most cases.
+        target=NumSourcesTask,
+        doc="Measure task")
+    
+class VisitAnalysisTask(MetricTask):
+
+    ConfigClass = VisitAnalysisTaskConfig
+    _DefaultName = "visitAnalysisTask"
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(*args, config=config, **kwargs)
+        self.makeSubtask('measure')
+
+    def run(self, source_catalog):
+        return self.measure.run(source_catalog, self.config.connections.metric)

--- a/tasks/VisitAnalysis.py
+++ b/tasks/VisitAnalysis.py
@@ -3,11 +3,10 @@ import lsst.pex.config as pexConfig
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
 from lsst.afw.table import SourceCatalog
 
-from VisitMeasureTasks import NumSourcesTask
+from GeneralMeasureTasks import NumSourcesTask
 
 # The first thing to do is to define a Connections class. This will define all
 # the inputs and outputs that our task requires
-
 class VisitAnalysisTaskConnections(MetricConnections,
                                    dimensions=("instrument", "visit", "abstract_filter")):
     
@@ -48,8 +47,6 @@ class VisitAnalysisTask(MetricTask):
         source_catalog = SourceCatalog(schema)
         source_catalog.reserve(size)
         for cat in source_catalogs:
-            #self.log.info('%i'%len(cat))
             source_catalog.extend(cat)
-        #self.log.info('Found a total of %i sources'%len(source_catalog))
         
         return self.measure.run(source_catalog, self.config.connections.metric)

--- a/tasks/VisitMeasureTasks.py
+++ b/tasks/VisitMeasureTasks.py
@@ -1,0 +1,15 @@
+import astropy.units as u
+from lsst.pipe.base import Struct, Task
+from lsst.pex.config import Config
+from lsst.verify import Measurement
+
+class NumSourcesTask(Task):
+
+    ConfigClass = Config
+    _DefaultName = "numSourcesTask"
+
+    def run(self, source_catalog, metric_name):
+        self.log.info(f"Counting sources in single-visit catalog")
+        nSources = len(source_catalog)
+        meas = Measurement("nsrcMeasVisit", nSources * u.count)
+        return Struct(measurement=meas)

--- a/tasks/VisitMeasureTasks.py
+++ b/tasks/VisitMeasureTasks.py
@@ -3,13 +3,4 @@ from lsst.pipe.base import Struct, Task
 from lsst.pex.config import Config
 from lsst.verify import Measurement
 
-class NumSourcesTask(Task):
-
-    ConfigClass = Config
-    _DefaultName = "numSourcesTask"
-
-    def run(self, source_catalog, metric_name):
-        self.log.info(f"Counting sources in single-visit catalog")
-        nSources = len(source_catalog)
-        meas = Measurement("nsrcMeasVisit", nSources * u.count)
-        return Struct(measurement=meas)
+#Currently this is a placeholder until additional per-visit measurements are added.


### PR DESCRIPTION
This is a first attempt at adding a per-visit metric. This version will run for me on `w_2020_21` with a command like

`pipetask run -j 1 -b "$CI_HSC_GEN3_DIR"/DATA/butler.yaml --register-dataset-types -p pipelines/visit_analysis.yaml -d "abstract_filter = 'r'" -o visitTest --replace-run`

Right now there is just a task that computes the number of sources in each individual visit. I have not yet confirmed that it is doing the right thing.