### PR TITLE
Add per-patch metric

### DIFF
--- a/pipelines/patch_agg.yaml
+++ b/pipelines/patch_agg.yaml
@@ -1,0 +1,8 @@
+description: Compute aggregate metrics from a list of individual measurements
+tasks:
+  agg_sum_nsrcPatch:
+    class: PatchAggregation.PatchAggregationTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasPatch
+      connections.agg_name: Sum

--- a/pipelines/patch_analysis.yaml
+++ b/pipelines/patch_analysis.yaml
@@ -1,0 +1,10 @@
+description: Compute metrics from patch forced catalogs
+tasks:
+  nsrcMeasPatch:
+    class: PatchAnalysis.PatchAnalysisTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasPatch
+      python: |
+        from GeneralMeasureTasks import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)

--- a/pipelines/patch_pipeline.yaml
+++ b/pipelines/patch_pipeline.yaml
@@ -1,0 +1,4 @@
+description: Patch metrics pipeline
+inherits:
+  - location: $METRIC_PIPE_DIR/pipelines/patch_analysis.yaml
+  - location: $METRIC_PIPE_DIR/pipelines/patch_agg.yaml

--- a/tasks/PatchAggregation.py
+++ b/tasks/PatchAggregation.py
@@ -1,0 +1,40 @@
+import astropy.units as u
+import numpy as np
+
+from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
+import lsst.pipe.base as pipeBase
+from lsst.verify import Measurement
+
+class PatchAggregationTaskConnections(MetricConnections,
+                                      defaultTemplates={'agg_name': None},
+                                      dimensions=("skymap", "abstract_filter")):
+    
+    measurements = pipeBase.connectionTypes.Input(doc="{package}_{metric}.",
+                                                  dimensions=("tract", "patch", "skymap", 
+                                                              "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}",
+                                                  multiple=True)
+    
+    measurement = pipeBase.connectionTypes.Output(doc="{agg_name} {package}_{metric}.",
+                                                  dimensions=("skymap", "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{agg_name}_{package}_{metric}")
+    
+class PatchAggregationTaskConfig(MetricConfig,
+                                 pipelineConnections=PatchAggregationTaskConnections):
+    pass
+
+class PatchAggregationTask(MetricTask):
+
+    ConfigClass = PatchAggregationTaskConfig
+    _DefaultName = "patchAggregationTask"
+
+    def run(self, measurements):
+        package = self.config.connections.package
+        metric = self.config.connections.metric
+        agg = self.config.connections.agg_name.lower()
+        self.log.info(f"Computing the {agg} of {package}_{metric} values in patch catalogs")
+
+        value = getattr(np, agg)(u.Quantity([x.quantity for x in measurements if np.isfinite(x.quantity)]))
+        return pipeBase.Struct(measurement=Measurement(f"metricvalue_{agg}_{package}_{metric}", value))

--- a/tasks/PatchAnalysis.py
+++ b/tasks/PatchAnalysis.py
@@ -1,0 +1,45 @@
+import lsst.pipe.base as pipeBase
+import lsst.pex.config as pexConfig
+from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
+from lsst.afw.table import SourceCatalog
+
+from GeneralMeasureTasks import NumSourcesTask
+
+# The first thing to do is to define a Connections class. This will define all
+# the inputs and outputs that our task requires
+class PatchAnalysisTaskConnections(MetricConnections,
+                                   dimensions=("tract", "patch", "skymap",
+                                               "abstract_filter")):
+    
+    object_catalog = pipeBase.connectionTypes.Input(doc="Object catalog.",
+                                                    dimensions=("tract", "patch", "skymap", 
+                                                                "abstract_filter"),
+                                                    storageClass="SourceCatalog",
+                                                    name="deepCoadd_forced_src")
+    
+    measurement = pipeBase.connectionTypes.Output(doc="Per-patch measurement.",
+                                                  dimensions=("tract", "patch", "skymap",
+                                                              "abstract_filter"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+    
+class PatchAnalysisTaskConfig(MetricConfig,
+                              pipelineConnections=PatchAnalysisTaskConnections):
+    measure = pexConfig.ConfigurableField(
+        # This task is meant to make measurements of various types.
+        # The default task is, therefore, a bit of a place holder.
+        # It is expected that this will be overridden in the pipeline
+        # definition in most cases.
+        target=NumSourcesTask,
+        doc="Measure task")
+    
+class PatchAnalysisTask(MetricTask):
+
+    ConfigClass = PatchAnalysisTaskConfig
+    _DefaultName = "patchAnalysisTask"
+    def __init__(self, config, *args, **kwargs):
+        super().__init__(*args, config=config, **kwargs)
+        self.makeSubtask('measure')
+
+    def run(self, object_catalog):
+        return self.measure.run(object_catalog, self.config.connections.metric)

--- a/tasks/PatchMeasureTasks.py
+++ b/tasks/PatchMeasureTasks.py
@@ -1,0 +1,6 @@
+import astropy.units as u
+from lsst.pipe.base import Struct, Task
+from lsst.pex.config import Config
+from lsst.verify import Measurement
+
+#Currently this is a placeholder until additional patch measurements are added.


### PR DESCRIPTION
This pull request is similar to #6, but computing metrics for object catalogs from individual patches (specifically `deepCoadd_forced_src`) instead of source catalogs from individual visits. I have verified that it runs to completion on `w_2020_21` with commands like

`pipetask run -j 1 -b "$CI_HSC_GEN3_DIR"/DATA/butler.yaml --register-dataset-types -p pipelines/patch_pipeline.yaml -d "abstract_filter = 'r'" -o patchTest -i shared/ci_hsc_output`

`pipetask run -j 1 -b "$CI_HSC_GEN3_DIR"/DATA/butler.yaml --register-dataset-types -p pipelines/patch_pipeline.yaml -d "abstract_filter = 'r'" -o patchTest --replace-run`

However, there seems to be only a single patch, so the aggregation step is less interesting.

It might be worth thinking about if there is another preferred spatial scale beside the patch to compute metrics from coadd catalogs.