### PR TITLE
Add tract/multi-band metric to default pipeline.

### DIFF
--- a/pipelines/analysis_tract_multi.yaml
+++ b/pipelines/analysis_tract_multi.yaml
@@ -1,0 +1,10 @@
+description: Compute metrics from multiband matched catalogs
+tasks:
+  wPerp:
+    class: metric_pipeline_tasks.TractAnalysisMultiFiltTask
+    config:
+      connections.package: pipe_analysis
+      connections.metric: wPerp
+      python: |
+        from metric_pipeline_tasks import WPerpTask
+        config.measure.retarget(WPerpTask)

--- a/pipelines/metrics_pipeline.yaml
+++ b/pipelines/metrics_pipeline.yaml
@@ -3,6 +3,7 @@ inherits:
   - location: $METRIC_PIPELINE_TASKS_DIR/pipelines/metrics_pipeline_matched.yaml
   - location: $METRIC_PIPELINE_TASKS_DIR/pipelines/metrics_pipeline_matched_multi.yaml
   - location: $METRIC_PIPELINE_TASKS_DIR/pipelines/metrics_pipeline_visit.yaml
+  - location: $METRIC_PIPELINE_TASKS_DIR/pipelines/metrics_pipeline_tract_multi.yaml
   # This pipeline only has data for one patch which causes all other
   # pipelines to run over only that patch
   #- location: $METRIC_PIPELINE_TASKS_DIR/pipelines/metrics_pipeline_patch.yaml

--- a/pipelines/metrics_pipeline_tract_multi.yaml
+++ b/pipelines/metrics_pipeline_tract_multi.yaml
@@ -1,0 +1,3 @@
+description: Full metrics pipeline
+inherits:
+  - location: $METRIC_PIPELINE_TASKS_DIR/pipelines/analysis_tract_multi.yaml


### PR DESCRIPTION
When I added the stellar locus metric (wPerp), I forgot to add this new type of "TractMulti" metric to the default metrics_pipeline.yaml.