### PR TITLE
Change deepCoadd_skyMap to skyMap in MatchedCatalogsBase.py

### DIFF
--- a/python/metric_pipeline_tasks/MatchedCatalogsBase.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogsBase.py
@@ -33,7 +33,7 @@ class MatchedBaseTaskConnections(pipeBase.PipelineTaskConnections,
                                                                multiple=True)
     skyMap = pipeBase.connectionTypes.Input(
         doc="Input definition of geometry/bbox and projection/wcs for warped exposures",
-        name="{coaddName}Coadd_skyMap",
+        name="skyMap",
         storageClass="SkyMap",
         dimensions=("skymap",),
     )


### PR DESCRIPTION
Small change required because of recent Gen3 middleware changes (I can't find the ticket though - got the tip from J. Bosch).