### PR TITLE
Fix numpy breakage of AB1.

### DIFF
--- a/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
@@ -294,7 +294,7 @@ class AB1Task(Task):
             if len(rmsDistancesAll) == 0:
                 return Struct(measurement=Measurement(metric_name, np.nan*u.marcsec))
             else:
-                rmsDistancesAll = np.array(np.concatenate(rmsDistancesAll))
+                rmsDistancesAll = np.concatenate(rmsDistancesAll)
                 return Struct(measurement=Measurement(metric_name, np.mean(rmsDistancesAll)*u.marcsec))
 
         else:

--- a/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
@@ -291,11 +291,12 @@ class AB1Task(Task):
                 if len(finiteEntries) > 0:
                     rmsDistancesAll.append(rmsDistances[finiteEntries])
 
-            rmsDistancesAll = np.array(rmsDistancesAll)
+            rmsDistancesAll = np.array(np.concatenate(rmsDistancesAll))
 
             if len(rmsDistancesAll) == 0:
                 return Struct(measurement=Measurement(metric_name, np.nan*u.marcsec))
-            return Struct(measurement=Measurement(metric_name, np.mean(rmsDistancesAll)*u.marcsec))
+            else:
+                return Struct(measurement=Measurement(metric_name, np.mean(rmsDistancesAll)*u.marcsec))
 
         else:
             return Struct(measurement=Measurement(metric_name, np.nan*u.marcsec))

--- a/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
@@ -291,11 +291,10 @@ class AB1Task(Task):
                 if len(finiteEntries) > 0:
                     rmsDistancesAll.append(rmsDistances[finiteEntries])
 
-            rmsDistancesAll = np.array(np.concatenate(rmsDistancesAll))
-
             if len(rmsDistancesAll) == 0:
                 return Struct(measurement=Measurement(metric_name, np.nan*u.marcsec))
             else:
+                rmsDistancesAll = np.array(np.concatenate(rmsDistancesAll))
                 return Struct(measurement=Measurement(metric_name, np.mean(rmsDistancesAll)*u.marcsec))
 
         else:


### PR DESCRIPTION
The previous numpy array creation was causing errors -- when all the arrays being combined were the same size, the array created would be a typical ndarray, but when one or more arrays was a different size, it would combine them as an object array with astropy units still attached. This caused problems in the return statement. 