### PR TITLE
Fix random seed for photometric repeatability sampling in configuration

### DIFF
--- a/pipelines/analysis_matched.yaml
+++ b/pipelines/analysis_matched.yaml
@@ -8,7 +8,6 @@ tasks:
       python: |
         from metric_pipeline_tasks import PA1Task
         config.measure.retarget(PA1Task)
-        config.measure.randomSeed = 12345
   PA2_design:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:
@@ -19,7 +18,6 @@ tasks:
         config.measure.retarget(PA2Task)
         config.measure.threshPA2 = 15.0
         config.measure.threshPF1 = 10.0
-        config.measure.randomSeed = 12345
   PF1_design:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:
@@ -30,7 +28,6 @@ tasks:
         config.measure.retarget(PF1Task)
         config.measure.threshPA2 = 15.0
         config.measure.threshPF1 = 10.0
-        config.measure.randomSeed = 12345
   AM1_info:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:

--- a/pipelines/analysis_matched.yaml
+++ b/pipelines/analysis_matched.yaml
@@ -8,6 +8,7 @@ tasks:
       python: |
         from metric_pipeline_tasks import PA1Task
         config.measure.retarget(PA1Task)
+        config.measure.randomSeed = 12345
   PA2_design:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:
@@ -18,6 +19,7 @@ tasks:
         config.measure.retarget(PA2Task)
         config.measure.threshPA2 = 15.0
         config.measure.threshPF1 = 10.0
+        config.measure.randomSeed = 12345
   PF1_design:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:
@@ -28,6 +30,7 @@ tasks:
         config.measure.retarget(PF1Task)
         config.measure.threshPA2 = 15.0
         config.measure.threshPF1 = 10.0
+        config.measure.randomSeed = 12345
   AM1_info:
     class: metric_pipeline_tasks.MatchedCatalogTractAnalysisTask
     config:

--- a/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
@@ -19,6 +19,8 @@ class PA1TaskConfig(Config):
                          dtype=float, default=50)
     brightSnrMax = Field(doc="Maximum median SNR for a source to be considered bright.",
                          dtype=float, default=np.Inf)
+    numRandomShuffles = Field(doc="Number of trials used for random sampling of observation pairs.",
+                              dtype=int, default=50)
     randomSeed = Field(doc="Random seed for sampling.",
                        dtype=int, default=12345)
 
@@ -32,14 +34,15 @@ class PA1Task(Task):
         super().__init__(*args, config=config, **kwargs)
         self.brightSnrMin = self.config.brightSnrMin
         self.brightSnrMax = self.config.brightSnrMax
+        self.numRandomShuffles = self.config.numRandomShuffles
         self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PA1")
 
-        pa1 = photRepeat(matchedCatalog, snrMax=self.brightSnrMax, snrMin=self.brightSnrMin, 
-                         randomSeed=self.randomSeed)
-        
+        pa1 = photRepeat(matchedCatalog, snrMax=self.brightSnrMax, snrMin=self.brightSnrMin,
+                         numRandomShuffles=self.numRandomShuffles, randomSeed=self.randomSeed)
+
         if 'magDiff' in pa1.keys():
             return Struct(measurement=Measurement("PA1", pa1['repeatability']))
         else:
@@ -55,6 +58,8 @@ class PA2TaskConfig(Config):
     threshPA2 = Field(doc="Threshold in mmag for PF1 calculation.", dtype=float, default=15.0)
     threshPF1 = Field(doc="Percentile of differences that can vary by more than threshPA2.",
                       dtype=float, default=10.0)
+    numRandomShuffles = Field(doc="Number of trials used for random sampling of observation pairs.",
+                              dtype=int, default=50)
     randomSeed = Field(doc="Random seed for sampling.",
                        dtype=int, default=12345)
 
@@ -70,13 +75,15 @@ class PA2Task(Task):
         self.brightSnrMax = self.config.brightSnrMax
         self.threshPA2 = self.config.threshPA2
         self.threshPF1 = self.config.threshPF1
+        self.numRandomShuffles = self.config.numRandomShuffles
         self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PA2")
         pf1_thresh = self.threshPF1 * u.percent
 
-        pa2 = photRepeat(matchedCatalog, randomSeed=self.randomSeed)
+        pa2 = photRepeat(matchedCatalog,
+                         numRandomShuffles=self.numRandomShuffles, randomSeed=self.randomSeed)
 
         if 'magDiff' in pa2.keys():
             # Previously, validate_drp used the first random sample from PA1 measurement
@@ -101,13 +108,15 @@ class PF1Task(Task):
         self.brightSnrMax = self.config.brightSnrMax
         self.threshPA2 = self.config.threshPA2
         self.threshPF1 = self.config.threshPF1
+        self.numRandomShuffles = self.config.numRandomShuffles
         self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PF1")
         pa2_thresh = self.threshPA2 * u.mmag
 
-        pf1 = photRepeat(matchedCatalog, randomSeed=self.randomSeed)
+        pf1 = photRepeat(matchedCatalog,
+                         numRandomShuffles=self.numRandomShuffles, randomSeed=self.randomSeed)
 
         if 'magDiff' in pf1.keys():
             # Previously, validate_drp used the first random sample from PA1 measurement

--- a/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
+++ b/python/metric_pipeline_tasks/MatchedCatalogMeasureTasks.py
@@ -19,6 +19,8 @@ class PA1TaskConfig(Config):
                          dtype=float, default=50)
     brightSnrMax = Field(doc="Maximum median SNR for a source to be considered bright.",
                          dtype=float, default=np.Inf)
+    randomSeed = Field(doc="Random seed for sampling.",
+                       dtype=int, default=12345)
 
 
 class PA1Task(Task):
@@ -30,12 +32,14 @@ class PA1Task(Task):
         super().__init__(*args, config=config, **kwargs)
         self.brightSnrMin = self.config.brightSnrMin
         self.brightSnrMax = self.config.brightSnrMax
+        self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PA1")
 
-        pa1 = photRepeat(matchedCatalog, snrMax=self.brightSnrMax, snrMin=self.brightSnrMin)
-
+        pa1 = photRepeat(matchedCatalog, snrMax=self.brightSnrMax, snrMin=self.brightSnrMin, 
+                         randomSeed=self.randomSeed)
+        
         if 'magDiff' in pa1.keys():
             return Struct(measurement=Measurement("PA1", pa1['repeatability']))
         else:
@@ -51,6 +55,8 @@ class PA2TaskConfig(Config):
     threshPA2 = Field(doc="Threshold in mmag for PF1 calculation.", dtype=float, default=15.0)
     threshPF1 = Field(doc="Percentile of differences that can vary by more than threshPA2.",
                       dtype=float, default=10.0)
+    randomSeed = Field(doc="Random seed for sampling.",
+                       dtype=int, default=12345)
 
 
 class PA2Task(Task):
@@ -64,12 +70,13 @@ class PA2Task(Task):
         self.brightSnrMax = self.config.brightSnrMax
         self.threshPA2 = self.config.threshPA2
         self.threshPF1 = self.config.threshPF1
+        self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PA2")
         pf1_thresh = self.threshPF1 * u.percent
 
-        pa2 = photRepeat(matchedCatalog)
+        pa2 = photRepeat(matchedCatalog, randomSeed=self.randomSeed)
 
         if 'magDiff' in pa2.keys():
             # Previously, validate_drp used the first random sample from PA1 measurement
@@ -94,12 +101,13 @@ class PF1Task(Task):
         self.brightSnrMax = self.config.brightSnrMax
         self.threshPA2 = self.config.threshPA2
         self.threshPF1 = self.config.threshPF1
+        self.randomSeed = self.config.randomSeed
 
     def run(self, matchedCatalog, metric_name):
         self.log.info(f"Measuring PF1")
         pa2_thresh = self.threshPA2 * u.mmag
 
-        pf1 = photRepeat(matchedCatalog)
+        pf1 = photRepeat(matchedCatalog, randomSeed=self.randomSeed)
 
         if 'magDiff' in pf1.keys():
             # Previously, validate_drp used the first random sample from PA1 measurement

--- a/python/metric_pipeline_utils/phot_repeat.py
+++ b/python/metric_pipeline_utils/phot_repeat.py
@@ -1,7 +1,6 @@
 import functools
 import math
 import numpy as np
-import random
 from scipy.stats import norm
 import astropy.units as u
 
@@ -114,7 +113,8 @@ def calcPhotRepeat(matches, magKey, numRandomShuffles=50, randomSeed=None):
     >>>     return np.isfinite(cat.get(magKey)).all()
     >>> repeat = calcPhotRepeat(allMatches.where(matchFilter), magKey)
     """
-    mprSamples = [calcPhotRepeatSample(matches, magKey, randomSeed=randomSeed)
+    rng = np.random.default_rng(randomSeed)
+    mprSamples = [calcPhotRepeatSample(matches, magKey, rng=rng)
                   for _ in range(numRandomShuffles)]
 
     rms = np.array([mpr.rms for mpr in mprSamples]) * u.mmag
@@ -125,7 +125,7 @@ def calcPhotRepeat(matches, magKey, numRandomShuffles=50, randomSeed=None):
     return {'rms': rms, 'iqr': iqr, 'magDiff': magDiff, 'magMean': magMean, 'repeatability': repeat}
 
 
-def calcPhotRepeatSample(matches, magKey, randomSeed=None):
+def calcPhotRepeatSample(matches, magKey, rng=None):
     """Compute one realization of repeatability by randomly sampling pairs of
     visits.
     Parameters
@@ -139,6 +139,8 @@ def calcPhotRepeatSample(matches, magKey, randomSeed=None):
         E.g., ``magKey = allMatches.schema.find("base_PsfFlux_mag").key``
         where ``allMatches`` is the result of
         `lsst.afw.table.MultiMatch.finish()`.
+    rng : `numpy.random._generator.Generator`
+        Input random number generator.
     Returns
     -------
     metrics : `lsst.pipe.base.Struct`
@@ -156,7 +158,7 @@ def calcPhotRepeatSample(matches, magKey, randomSeed=None):
     calcPhotRepeat : A wrapper that repeatedly calls this function to build
         the repeatability measurement.
     """
-    sampler = functools.partial(getRandomDiffRmsInMags, randomSeed=randomSeed)
+    sampler = functools.partial(getRandomDiffRmsInMmags, rng=rng)
     magDiffs = matches.aggregate(sampler, field=magKey)
     magMean = matches.aggregate(np.mean, field=magKey)
     rms, iqr = computeWidths(magDiffs)
@@ -189,13 +191,15 @@ def computeWidths(array):
     return rmsSigma, iqrSigma
 
 
-def getRandomDiffRmsInMmags(array, randomSeed=None):
+def getRandomDiffRmsInMmags(array, rng=None):
     """Calculate the RMS difference in mmag between a random pairing of
     visits of a source.
     Parameters
     ----------
     array : `list` or `numpy.ndarray`
         Magnitudes from which to select the pair [mag].
+    rng : `numpy.random._generator.Generator`
+        Input random number generator.
     Returns
     -------
     rmsMmags : `float`
@@ -220,23 +224,23 @@ def getRandomDiffRmsInMmags(array, randomSeed=None):
     212.132034
     """
     thousandDivSqrtTwo = 1000/math.sqrt(2)
-    return thousandDivSqrtTwo * getRandomDiff(array, randomSeed=randomSeed)
+    return thousandDivSqrtTwo * getRandomDiff(array, rng=rng)
 
 
-def getRandomDiff(array, randomSeed=None):
+def getRandomDiff(array, rng=None):
     """Get the difference between two randomly selected elements of an array.
     Parameters
     ----------
     array : `list` or `numpy.ndarray`
         Input array.
+    rng : `numpy.random._generator.Generator`
+        Input random number generator.
     Returns
     -------
     float or int
         Difference between two random elements of the array.
     """
-    if not randomSeed:
+    if not rng:
         rng = np.random.default_rng()
-    else:
-        rng = np.random.default_rng(randomSeed)
     a, b = rng.choice(range(len(array)), 2)
     return array[a] - array[b]

--- a/python/metric_pipeline_utils/phot_repeat.py
+++ b/python/metric_pipeline_utils/phot_repeat.py
@@ -242,5 +242,5 @@ def getRandomDiff(array, rng=None):
     """
     if not rng:
         rng = np.random.default_rng()
-    a, b = rng.choice(range(len(array)), 2)
+    a, b = rng.choice(range(len(array)), 2, replace=False)
     return array[a] - array[b]

--- a/python/metric_pipeline_utils/phot_repeat.py
+++ b/python/metric_pipeline_utils/phot_repeat.py
@@ -8,14 +8,14 @@ import lsst.pipe.base as pipeBase
 from metric_pipeline_utils.filtermatches import filterMatches
 
 
-def photRepeat(matchedCatalog, randomSeed=None, **filterargs):
+def photRepeat(matchedCatalog, numRandomShuffles=50, randomSeed=None, **filterargs):
     filteredCat = filterMatches(matchedCatalog, **filterargs)
     magKey = filteredCat.schema.find('slot_PsfFlux_mag').key
 
     # Require at least nMinPhotRepeat objects to calculate the repeatability:
     nMinPhotRepeat = 50
     if filteredCat.count > nMinPhotRepeat:
-        phot_resid_meas = calcPhotRepeat(filteredCat, magKey, randomSeed=randomSeed)
+        phot_resid_meas = calcPhotRepeat(filteredCat, magKey, numRandomShuffles=50, randomSeed=randomSeed)
         return phot_resid_meas
     else:
         return {'nomeas': np.nan*u.mmag}


### PR DESCRIPTION
This PR adds the option to set the seed for random number generation for the photometric repeatability calculations in configuration. 

The photometric repeatability calculations involve random sampling of pairs of observations for each object. In each trial, a random pair of observations is drawn for each object. In general, there are multiple trials. The sampling of pairs is done by the `getRandomDiff` function. The `getRandomDiff` function is called within a `GroupView.aggregate` loop, and currently, there isn't a way to pass a random seed argument using `GroupView.aggregate`.

The approach I've taken in this PR, inspired by @SimonKrughoff , is use `functools.partial` to pass an instance of a random number generator `np.random.default_rng` into `getRandomDiff`. The random number generator can use an optional seed set in configuration. The random number generator instance is set _before_ starting the loop over trials in `calcPhotRepeat`. In this way, each individual trial will be a statistically independent set of random draws, but the ensemble of draws is repeatable. One can see the behavior by doing a standalone test in a notebook

```
from metric_pipeline_utils.phot_repeat import getRandomDiff
import functools
import numpy as np

seed=12345
#seed=None
getRandomDiff = functools.partial(getRandomDiff, rng=np.random.default_rng(seed))

for ii in range(0, 10):
    print(getRandomDiff(np.arange(20)))
```

One the random seed is set, the sequence of draws is repeatable. If the seed is set to `None` the draws are not repeatable.

I think this approach has a few advantages. It does not touch the global random number generator. By passing in an instance of a random number generator with `functools.partial`, one does not need to reset the seed in each call to `getRandomDiff`. This means that the sampling for each object and each trial is statistically independent, which is I think the behavior we want. 

I've put hooks into setting the random seed in both `photRepeat` and `calcPhotRepeat` to hopefully make testing these individual functions in a modular way easier. I don't think we want to set the seed in `calcPhotRepeatSample` because this would make each trial identical.

If we like this general approach, perhaps it could be a model for other situations where we want a repeatable sampling for metrics.